### PR TITLE
Request #18 : allowing pre-assigned roles to be kept

### DIFF
--- a/src/com/dotcms/plugin/saml/v3/OpenSamlAuthenticationServiceImpl.java
+++ b/src/com/dotcms/plugin/saml/v3/OpenSamlAuthenticationServiceImpl.java
@@ -369,9 +369,12 @@ public class OpenSamlAuthenticationServiceImpl implements SamlAuthenticationServ
 
         try {
 
-            // remove previous roles
-            Logger.debug(this, "Removing user previous roles");
-            this.roleAPI.removeAllRolesFromUser(user);
+        	if (attributesBean.isAddRoles() ||
+        			configuration.getStringProperty(DOTCMS_SAML_OPTIONAL_USER_ROLE, null) != null ) {
+        		// remove previous roles
+        		Logger.debug(this, "Removing user previous roles");
+        		this.roleAPI.removeAllRolesFromUser(user);
+        	}
 
             if (attributesBean.isAddRoles() &&
                 null != attributesBean.getRoles() &&


### PR DESCRIPTION
No need for an additional config property, for roles won’t be synched
if the attribute DOT_SAML_ROLES_ATTRIBUTE is not contained in the
responses from the idP.

We do need to avoid removing pre-assigned roles when no
DOT_SAML_ROLES_ATTRIBUTE is present and no
DOTCMS_SAML_OPTIONAL_USER_ROLE is defined.