### PR TITLE
Issue #26 removed validation for mandatory role prefix and filter

### DIFF
--- a/src/com/dotcms/plugin/saml/v3/config/SiteConfigurationParser.java
+++ b/src/com/dotcms/plugin/saml/v3/config/SiteConfigurationParser.java
@@ -133,8 +133,6 @@ public class SiteConfigurationParser implements Serializable {
                 fieldsToValidate.add(DotSamlConstants.DOTCMS_SAML_KEY_STORE_PASSWORD);
                 fieldsToValidate.add(DotSamlConstants.DOTCMS_SAML_KEY_ENTRY_ID);
                 fieldsToValidate.add(DotSamlConstants.DOTCMS_SAML_KEY_STORE_ENTRY_PASSWORD);
-                fieldsToValidate.add(DotSamlConstants.DOT_SAML_REMOVE_ROLES_PREFIX);
-                fieldsToValidate.add(DotSamlConstants.DOTCMS_SAML_INCLUDE_ROLES_PATTERN);
 
                 Set<String> missingFields = SamlUtils.getMissingProperties(samlProperties, fieldsToValidate);
 


### PR DESCRIPTION
Removed DOT_SAML_REMOVE_ROLES_PREFIX and
DOTCMS_SAML_INCLUDE_ROLES_PATTERN from the mandatory property
validation of the host.